### PR TITLE
Upgrade to latest version of langchain and use UV package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ This streamlit application accepts a code or a function as an input and generate
 4. Start the streamlit app, should open a brower window; if not open manually (the output of below command provides the url)
     > streamlit run main.py
 
+## Installation using UV package manager
+1. Clone the repository.
+2. Install UV package manager from https://uv.pm
+3. Install dependencies using UV package manager
+    > uv install
+4. Start the streamlit app, should open a brower window; if not open manually (the output of below command provides the url)
+    > streamlit run main.py
+
 ## How it works
 It is wonderful to see how frameworks like LangChain make it easier to work with LLMs, they provide a simplified api which allows to interact with LLMs. Refer to the LangChain docs for more information.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-langchain==0.0.352
+langchain==0.0.353
 google-cloud-aiplatform==1.38.1
 streamlit==1.29.0

--- a/uv.yml
+++ b/uv.yml
@@ -1,0 +1,4 @@
+dependencies:
+  - langchain
+  - google-cloud-aiplatform
+  - streamlit


### PR DESCRIPTION
Related to #2

Upgrade `langchain` to the latest version and add UV package manager configuration.

* **`requirements.txt`**
  - Upgrade `langchain` to version 0.0.353.

* **`uv.yml`**
  - Add UV package manager configuration file.
  - Specify dependencies: `langchain`, `google-cloud-aiplatform`, `streamlit`.

* **`README.md`**
  - Update installation instructions to use UV package manager.
  - Add a section explaining how to use UV package manager.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/laxman-munigala/langchain-vertexai-gemini-codeadvisor/pull/3?shareId=fa7dfe55-7121-4672-b5e2-99a88ed9c3fd).